### PR TITLE
Fix two issues with the theme's search box and sidebar

### DIFF
--- a/packages/vuepress-theme-book/styles/index.styl
+++ b/packages/vuepress-theme-book/styles/index.styl
@@ -46,7 +46,7 @@ body .navbar .site-name, h1, h2
           background-position-y: 50%
 
     #search-form
-      line-height inherit
+      line-height: inherit
 
 // SIDEBAR
 

--- a/packages/vuepress-theme-book/styles/index.styl
+++ b/packages/vuepress-theme-book/styles/index.styl
@@ -45,6 +45,9 @@ body .navbar .site-name, h1, h2
           background-size: 0.9rem
           background-position-y: 50%
 
+    #search-form
+      line-height inherit
+
 // SIDEBAR
 
 .sidebar

--- a/packages/vuepress-theme-book/styles/index.styl
+++ b/packages/vuepress-theme-book/styles/index.styl
@@ -79,7 +79,7 @@ body .navbar .site-name, h1, h2
 
     &:hover
       color: $textColor
-      background-color: $lightDelimiterColor
+      background-color: $lightDelimiterColor !important
 
     &.active
       border-color: $lightDelimiterColor


### PR DESCRIPTION
## Fixes

- Fix the search bar not being vertically aligned when using Algolia. This is tested on my documentation site: [spencerwooo/dowww](https://dowww.spencerwoo.com).
- Fix the sidebar hover effect for items with depth larger than 2.

## Problem 1: Algolia search box

The search box selector is `#search-form` when Algolia is enabled. If the `line-height` attribute is not specified, then we end up with a search box not vertically aligned.

![Snipaste_2020-09-02_15-44-45](https://user-images.githubusercontent.com/32114380/91965699-7208ea00-ed43-11ea-8a51-6005204d21cc.png)

## Problem 2: sidebar hover effect

For sidebar links with depth more than 2, if we don't add the `!important`, then the style is overridden by default, i.e., we won't get the background color change on hover.

I've tested both fixes on my site and added them inside my custom [`.vuepress/styles/index.styl`](https://github.com/spencerwooo/dowww/blob/master/docs/.vuepress/styles/index.styl#L29-L33), both are working, so I assume this PR will resolve these issues.