### PR TITLE
Fix search box is not vertical aligned without nav

### DIFF
--- a/packages/vuepress-theme-book/styles/index.styl
+++ b/packages/vuepress-theme-book/styles/index.styl
@@ -12,7 +12,6 @@ body .navbar .site-name, h1, h2
 
     .search-box
       font-size: 1rem
-      line-height: 1.625
       border-radius: 3px
       margin: 0 0 0 1rem
 


### PR DESCRIPTION
Fix search box is not vertical aligned without nav.
If nav is not set, there will be a problem on the search box.
<br />
![problem](https://user-images.githubusercontent.com/26135245/95935670-5dba1180-0e06-11eb-97c3-b1821242cae0.png)

